### PR TITLE
add typescript declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
   "type": "module",
   "files": [
     "dist",
-    "src"
+    "src",
+    "src/index.d.ts"
   ],
+  "types": "src/index.d.ts",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,22 @@
+declare module "latibro-core" {
+    export interface Orbit {
+      items: string[];
+      customRadius?: number;
+      borderColor?: string;
+      borderStyle?: string;
+      borderWidth?: number;
+      customCss?: string;
+      speed?: number;
+    }
+  
+    export interface OrbitalOptions {
+      orbits: Orbit[];
+      orbitSpacing?: number;
+      backgroundColor?: string;
+    }
+  
+    export default class Orbital {
+      constructor(container: HTMLElement, options: OrbitalOptions);
+    }
+  }
+  


### PR DESCRIPTION
this PR adds a TypeScript declaration file for the module. This should correct the warning displayed in VSCode when importing the module.